### PR TITLE
Fix `reverseproxy` networks not external. Now it can be deployed first.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,6 @@ jobs:
         run: poetry run python manage.py migrate --settings=config.settings.local
       - name: fill database
         run: poetry run python manage.py loaddata --settings=config.settings.local e2e_tests/database/test_database.json
-      - name: create networks
-        run: |
-          docker network create testing_nginx_network
-          docker network create production_nginx_network
       - name: start reverse-proxy
         run: docker compose -f docker/reverseproxy/docker-compose.yml up -d --build
       - name: build testing application

--- a/deploy.sh
+++ b/deploy.sh
@@ -55,7 +55,7 @@ docker tag cpmonitor:${env} cpmonitor:${env}-${date}${tag_suffix}
 docker tag klimaschutzmonitor-dbeaver:${env} klimaschutzmonitor-dbeaver:${env}-${date}${tag_suffix}
 
 # backup the db and images
-~/backup.sh $env
+~/backup.sh $env || echo "Backup not possible. Continuing."
 
 # Stop the server, apply the migrations, start the server
 cd ~/${env}/

--- a/docker/reverseproxy/docker-compose.yml
+++ b/docker/reverseproxy/docker-compose.yml
@@ -30,11 +30,9 @@ networks:
   production_nginx_network:
     name: production_nginx_network
     driver: bridge
-    external: true
   testing_nginx_network:
     name: testing_nginx_network
     driver: bridge
-    external: true
   reverse_proxy_network:
     name: reverse_proxy_network
     driver: bridge


### PR DESCRIPTION
@fblampe Ohne das konnte ich den `reverseproxy` nicht vor den anderen Containern starten.
Kannst Du mal schauen, ob ich da was falsch verstanden habe?

Ich denke, das mit den nicht-externen Networks funktioniert so auch noch nicht, weil in `deploy.sh` der `reverseproxy` gestoppt und gestartet wird. Das hakelt sich vermutlich mit den laufenden cpmonitor Containern. Also entweder gut dokumentieren, dass die beiden Networks vorher manuell angelegt werden müssen oder das doch irgendwie so zum Laufen bringen - z.B. indem die Reverseproxy Aktualisierung irgendwie anders gemacht wird... Ich stecke in Docker zu wenig drin und sollte das wohl auch nicht aus dem Urlaub so nebenbei machen...