### PR TITLE
[#493] Add endpoints for cities and tasks which are not in draft mode

### DIFF
--- a/cpmonitor/serializers.py
+++ b/cpmonitor/serializers.py
@@ -86,6 +86,7 @@ class CitySerializer(serializers.ModelSerializer):
         model = City
         fields = [
             "id",
+            "draft_mode",
             "name",
             "municipality_key",
             "url",
@@ -114,6 +115,7 @@ class TaskSerializer(serializers.ModelSerializer):
         model = Task
         fields = [
             "id",
+            "draft_mode",
             "title",
             "city",
             "teaser",
@@ -137,5 +139,40 @@ class TaskSerializer(serializers.ModelSerializer):
 
     def get_children(self, obj):
         children = obj.get_children()
+        serializer = TaskSerializer(children, many=True)
+        return serializer.data
+
+
+class TaskWithoutDraftModeSerializer(serializers.ModelSerializer):
+    children = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Task
+        fields = [
+            "id",
+            "draft_mode",
+            "title",
+            "city",
+            "teaser",
+            "description",
+            "planned_start",
+            "planned_completion",
+            "responsible_organ",
+            "responsible_organ_explanation",
+            "plan_assessment",
+            "execution_status",
+            "execution_justification",
+            "supporting_ngos",
+            "execution_completion",
+            "actual_start",
+            "actual_completion",
+            "internal_information",
+            "slugs",
+            "numchild",
+            "children",
+        ]
+
+    def get_children(self, obj):
+        children = obj.get_children().exclude(draft_mode=True)
         serializer = TaskSerializer(children, many=True)
         return serializer.data

--- a/cpmonitor/urls.py
+++ b/cpmonitor/urls.py
@@ -71,6 +71,11 @@ urlpatterns = [
     # Use accept header "application/json" to get json
     #
     path("api/cities", views.CityList.as_view()),
+    path("api/cities-without-drafts", views.CityListWithoutDraftMode.as_view()),
     path("api/cities/<str:slug>", views.CityDetail.as_view()),
-    path("api/cities/<str:slug>/tasks", views.TasksbyCity.as_view()),
+    path("api/cities/<str:slug>/tasks", views.TasksByCity.as_view()),
+    path(
+        "api/cities/<str:slug>/tasks-without-drafts",
+        views.TasksByCityWithoutDraftMode.as_view(),
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/cpmonitor/views.py
+++ b/cpmonitor/views.py
@@ -43,6 +43,7 @@ from .models import (
 
 from .serializers import CitySerializer
 from .serializers import TaskSerializer
+from .serializers import TaskWithoutDraftModeSerializer
 
 from .utils import RemainingTimeInfo
 
@@ -821,7 +822,11 @@ class CityDetail(APIView):
         return Response(serializer.data)
 
 
-class TasksbyCity(APIView):
+class TasksByCity(APIView):
+    """
+    List all tasks of a city.
+    """
+
     def get(self, request, slug):
         try:
             city = City.objects.get(slug=slug)
@@ -830,4 +835,37 @@ class TasksbyCity(APIView):
         city_id = city.id
         children = Task.get_root_nodes().filter(city=city_id)
         serializer = TaskSerializer(children, many=True)
+        return Response(serializer.data)
+
+
+#
+# Temporary endpoints as dirty quick fix
+# for Bundestreffen 2024 for filtering out drafts
+#
+
+
+class CityListWithoutDraftMode(APIView):
+    """
+    List all cities which are not in draft mode.
+    """
+
+    def get(self, request):
+        cities = City.objects.all().exclude(draft_mode=True)
+        serializer = CitySerializer(cities, many=True)
+        return Response(serializer.data)
+
+
+class TasksByCityWithoutDraftMode(APIView):
+    """
+    List all tasks of a city which are not in draft mode.
+    """
+
+    def get(self, request, slug):
+        try:
+            city = City.objects.get(slug=slug)
+        except City.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        city_id = city.id
+        children = Task.get_root_nodes().filter(city=city_id, draft_mode=False)
+        serializer = TaskWithoutDraftModeSerializer(children, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
As discussed in the stand up today we need a temporary quick fix: two new endpoints which are returning only cities and tasks which are not in draft mode:

- api/cities-without-drafts
- api/cities/<str:slug>/tasks-without-drafts

