### PR TITLE
fix(fonts): add space to PT Serif to make font naming correct

### DIFF
--- a/frontend/app/globals.scss
+++ b/frontend/app/globals.scss
@@ -164,7 +164,7 @@
 @mixin heading {
   color: common.$gz-secondary-color;
   position: relative;
-  font-family: PTSerif;
+  font-family: PT Serif;
   line-height: 1.43;
 }
 


### PR DESCRIPTION
There was only one space missing in the font name in order for it to be correctly recognized (PTSerif vs PT Serif).

**Before**
<img width="750" alt="image" src="https://github.com/user-attachments/assets/8d82e860-5b69-46c2-9d80-b42c2e620df9" />


**Now**
<img width="777" alt="image" src="https://github.com/user-attachments/assets/e05a51ec-d622-4892-9857-d424cd5658e9" />
