### PR TITLE
refactor(massnahmen): remove double display of supporting ngos

### DIFF
--- a/frontend/app/(dashboard)/[city]/massnahmen/[...task]/page.tsx
+++ b/frontend/app/(dashboard)/[city]/massnahmen/[...task]/page.tsx
@@ -81,7 +81,7 @@ export default async function TaskDetails({ params }: { params: { city: string, 
       const assestment = task.plan_assessment ? <><h1 className="headingWithBar">Bewertung der geplanten Maßnahme</h1><CustomMarkdown content={task?.plan_assessment}></CustomMarkdown></> : <></>
       const execution = task.execution_justification ? <><h1 className="headingWithBar">Begründung Umsetzungsstand</h1><CustomMarkdown content={task?.execution_justification}></CustomMarkdown></> : <></>
       const explanation = task.responsible_organ_explanation ? <><h1 className="headingWithBar">Zuständige Instanz</h1><CustomMarkdown content={task?.responsible_organ_explanation}></CustomMarkdown></> : <></>
-      const supporting_ngos = task.supporting_ngos ? <><h1 className="headingWithBar">Mit Unterstützung von</h1><CustomMarkdown content={task?.supporting_ngos}></CustomMarkdown></> : <></>
+    
 
 
   return (
@@ -106,7 +106,6 @@ export default async function TaskDetails({ params }: { params: { city: string, 
               {assestment}
               {execution}
               {explanation}
-              {supporting_ngos}
             </div>
           </div>
         </Col>

--- a/frontend/app/(dashboard)/[city]/massnahmen/[...task]/page.tsx
+++ b/frontend/app/(dashboard)/[city]/massnahmen/[...task]/page.tsx
@@ -81,8 +81,6 @@ export default async function TaskDetails({ params }: { params: { city: string, 
       const assestment = task.plan_assessment ? <><h1 className="headingWithBar">Bewertung der geplanten Maßnahme</h1><CustomMarkdown content={task?.plan_assessment}></CustomMarkdown></> : <></>
       const execution = task.execution_justification ? <><h1 className="headingWithBar">Begründung Umsetzungsstand</h1><CustomMarkdown content={task?.execution_justification}></CustomMarkdown></> : <></>
       const explanation = task.responsible_organ_explanation ? <><h1 className="headingWithBar">Zuständige Instanz</h1><CustomMarkdown content={task?.responsible_organ_explanation}></CustomMarkdown></> : <></>
-    
-
 
   return (
     <Container className={`${styles.container} ${task.source === 1 ? styles.top : ""}`}>


### PR DESCRIPTION
As described in the ticket, there was a doubling of information concerning the supporting ngos. As suggested, the ngo name was removed from the content, since it's present inside the left sidebar already.

| Before | Now |
|--------|--------|
| <img width="1060" alt="image" src="https://github.com/user-attachments/assets/7c039768-9f1c-4631-9689-0d2ae9219150" /> | <img width="1042" alt="image" src="https://github.com/user-attachments/assets/62e9bfbe-a7d4-4d9c-a271-cc8de5eeb8d0" /> |