### PR TITLE
Don't expose container ports unnecessarily

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,6 @@ services:
   nginx-unprivileged:
     container_name: nginx-${ENVIRONMENT_NAME}
     image: nginxinc/nginx-unprivileged:alpine
-    ports:
-      - 8080
     volumes:
       - nginx_config_volume:/etc/nginx/conf.d
       - nginx_extras_volume:/etc/nginx/conf.d/extras


### PR DESCRIPTION
The nginx instances for testing and production are reachable via their respective docker networks testing_nginx_network and production_nginx_network, and the reverse-proxy composition, which shares these networks.