### PR TITLE
refactor(header): turn topmassnahmen into external link and make first nav item flat

### DIFF
--- a/frontend/app/(pages)/projektbeschreibung/page.tsx
+++ b/frontend/app/(pages)/projektbeschreibung/page.tsx
@@ -1,25 +1,20 @@
 import { Container } from "react-bootstrap";
 
 export default async function ProjectDescription() {
-
   return (
     <Container>
-      <div className="py-3 w-sm-50 m-auto">
-        <h1 className="big-h1">DAS PROJEKT</h1>
-
+      <div className="w-sm-50 m-auto py-3">
         In vielen Kommunen geraten die Bemühungen um Klimaneutralität früher oder später ins Stocken. Kein Wunder, denn
         es gibt bundesweit keine Blaupause dafür, wie dieses Ziel zu erreichen ist. Die Kommunen und ihre Bürger:innen
         begehen hier permanent Neuland und stoßen auf zahlreiche Fragen und Hindernisse. Für Bürger:innen ist häufig
         nicht ersichtlich, ob ihre Kommune überhaupt Fortschritte erzielt.
       </div>
       <h1 className="headingWithBar w-sm-75 m-auto">Kommunen im Monitoring</h1>
-      <div className="py-3 w-sm-50 m-auto">
+      <div className="w-sm-50 m-auto py-3">
         <p>
           Deshalb hat LocalZero die Plattform LocalMonitoring ins Leben gerufen. LocalMonitoring macht Fortschritte
           sichtbar, damit sie gefeiert werden können – und es zeigt Hürden auf, damit sie beseitigt werden können.
         </p>
-
-
         <h4 className="pt-2">Im Fokus der Bewertung stehen drei Aspekte:</h4>
         <ul>
           <li>Der Klima-Aktionsplan einer Kommune</li>
@@ -59,7 +54,7 @@ export default async function ProjectDescription() {
         </ul>
       </div>
       <h1 className="headingWithBar w-sm-75 m-auto">Über uns</h1>
-      <div className="py-3 w-sm-50 m-auto">
+      <div className="w-sm-50 m-auto py-3">
         <h4>LocalMonitoring wird ehrenamtlich von engagierten Bürger:innen der jeweiligen Stadt betrieben.</h4>
         LocalMonitoring ist ein Projekt der Initiative LocalZero, dem Netzwerk für kommunale Klimaneutralität unter dem
         Dach von{" "}

--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -36,13 +36,8 @@ export default function Header() {
             <Nav.Link
               href="https://mitmachen-wiki.germanzero.org/w/LocalZero:Top_Ma%C3%9Fnahmen_f%C3%BCr_Kommunen"
               target="_blank"
+              aria-label="Öffne das Germanzero Wiki in neuem Tab"
             >
-              <Image
-                width={30}
-                height={15}
-                src={arrow}
-                alt="little arrow"
-              ></Image>
               TOP MASSNAHMEN
             </Nav.Link>
           </Nav>

--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useState } from 'react';
+import { useState } from "react";
 import { Container, Navbar, Nav, NavDropdown } from "react-bootstrap";
 import Image from "next/image";
 import logo from "@/public/logo.png";
 import spende from "@/public/spende.svg";
+import arrow from "@/public/imgs/arrow-right-down.svg";
 
 export default function Header() {
   const [showDropdown, setShowDropdown] = useState(false);
@@ -25,23 +26,31 @@ export default function Header() {
         </Navbar.Brand>
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav">
-          <Nav fill className="fw-bold flex-grow-1">
-            <NavDropdown
-              title="MONITORING"
-              show={showDropdown}
-              onMouseEnter={() => setShowDropdown(true)}
-              onMouseLeave={() => setShowDropdown(false)}
-              onClick={() => setShowDropdown(!showDropdown)}
-            >
-              <div className="dropDownDivider"></div>
-              <NavDropdown.Item href="/">ALLE KOMMUNEN</NavDropdown.Item>
-              <NavDropdown.Item href="/projektbeschreibung">ÜBER DAS PROJEKT</NavDropdown.Item>
-            </NavDropdown>
+          <Nav
+            fill
+            className="fw-bold flex-grow-1"
+          >
+            <Nav.Link href="/">ALLE KOMMUNEN</Nav.Link>
+            <Nav.Link href="/projektbeschreibung">ÜBER DAS PROJEKT</Nav.Link>
 
-            <Nav.Link href="/topmassnahmen">TOP MASSNAHMEN</Nav.Link>
+            <Nav.Link
+              href="https://mitmachen-wiki.germanzero.org/w/LocalZero:Top_Ma%C3%9Fnahmen_f%C3%BCr_Kommunen"
+              target="_blank"
+            >
+              <Image
+                width={30}
+                height={15}
+                src={arrow}
+                alt="little arrow"
+              ></Image>
+              TOP MASSNAHMEN
+            </Nav.Link>
           </Nav>
 
-          <Navbar.Brand href="https://localzero.net/jetzt-spenden" target="new">
+          <Navbar.Brand
+            href="https://localzero.net/jetzt-spenden"
+            target="new"
+          >
             <Image
               src={spende}
               width={200}


### PR DESCRIPTION
As desired in the ticket, the Topmaßnahmen nav item is now an external link.

I additionally turned the first menu item from a dropdown into 2 items since the hierarchy seemed over-engineered and we had 3 items linking to the same page ("Monitoring", "Alle Kommunen" AND the logo itself).

| Was | Is Now |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5ca25079-5288-4d4c-9cbd-a5730c37cbb4) | <img width="1181" alt="image" src="https://github.com/user-attachments/assets/faa79117-8ffd-42de-a5d9-266bd6392917" /> |